### PR TITLE
Build AppImages with appimagecraft

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,3 +71,13 @@ CMakeLists.txt.user*
 
 # KDEvelop
 .kdev4/
+
+# JetBrains
+.idea/
+
+# Editor backups
+*.save
+*.swp
+
+# Build artifacts
+*.AppImage

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,7 +19,7 @@
 ## along with this program.  If not, see <http://www.gnu.org/licenses/>.
 ##
 
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.6)
 
 include(GNUInstallDirs)
 
@@ -85,7 +85,7 @@ set(LIBSR_CXX_BINDING "libsigrokcxx>=0.6.0")
 list(APPEND PKGDEPS "${LIBSR_CXX_BINDING}")
 
 find_package(PkgConfig)
-pkg_check_modules(LIBSRCXX ${LIBSR_CXX_BINDING})
+pkg_check_modules(LIBSRCXX ${LIBSR_CXX_BINDING} IMPORTED_TARGET)
 if(NOT LIBSRCXX_FOUND OR NOT LIBSRCXX_VERSION)
 	message(FATAL_ERROR "libsigrok C++ bindings missing, check libsigrok's 'configure' output (missing dependencies?)")
 endif()
@@ -383,6 +383,7 @@ set(SMUVIEW_LINK_LIBS
 	${CMAKE_THREAD_LIBS_INIT}
 #	${LIBATOMIC_LIBRARY}
 	pybind11::embed
+	PkgConfig::LIBSRCXX
 )
 
 if(STATIC_PKGDEPS_LIBS)

--- a/appimagecraft.yml
+++ b/appimagecraft.yml
@@ -1,0 +1,70 @@
+version: 1
+
+project:
+  name: com.github.knarfs.smuview
+  version_command: git describe --tags
+
+build:
+  cmake:
+    extra_variables:
+      # taken from some other script
+      - DISABLE_WERROR=y
+      - CMAKE_EXPORT_COMPILE_COMMANDS=y
+    raw_environment:
+      # we have to pre-build some dependencies, and also want to ship our own custom Python environment
+      # the CMake build system has been instructed to load the dependencies via pkg-config
+      - PKG_CONFIG_PATH="$BUILD_DIR"/deps/lib/pkgconfig:"$BUILD_DIR"/AppDir/usr/conda/lib/pkgconfig
+      # also we want to use a newer CMake version
+      - PATH="$BUILD_DIR"/deps/bin:"$PATH"
+
+scripts:
+  pre_build:
+    - pushd "$BUILD_DIR"
+    - |2
+      # we need a more recent version of libsigrok, and while we're at it, we can also build libserialport
+      for i in libserialport libsigrok; do
+          git clone git://sigrok.org/"$i"
+          pushd "$i"
+          ./autogen.sh
+          # once libserialport is built, libsigrok can be linked against it
+          export PKG_CONFIG_PATH="$BUILD_DIR"/deps/lib/pkgconfig
+          ./configure --prefix="$BUILD_DIR"/deps
+          make -j$(nprocs)
+          make install
+          popd
+      done
+    - popd
+    - |2
+      # unfortunately we need the Python environment before the build already, therefore we have to run the conda
+      # plugin manually before the build
+      wget https://github.com/linuxdeploy/linuxdeploy-plugin-conda/raw/master/linuxdeploy-plugin-conda.sh
+      # we need to skip the built-in cleanup as the build needs the development files (headers, libs, ...)
+      export CONDA_SKIP_CLEANUP=1
+      chmod +x linuxdeploy-plugin-conda.sh
+      ./linuxdeploy-plugin-conda.sh --appdir AppDir
+      . AppDir/usr/conda/bin/activate
+
+  post_build:
+    - |2
+      cat > "$BUILD_DIR"/AppRun.sh <<\EOF
+      #! /bin/bash
+
+      # make sure APPDIR variable is populated to allow for running from extracted AppDir as well
+      export APPDIR=${APPDIR:-$(readlink -f $(dirname "$0"))}
+
+      # load miniconda environment
+      . "$APPDIR"/usr/conda/etc/profile.d/conda.sh
+      conda activate "$@"
+
+      # finally, run smuview application
+      exec "$APPDIR"/usr/bin/smuview
+      EOF
+    - chmod +x "$BUILD_DIR"/AppRun.sh
+
+appimage:
+  linuxdeploy:
+    plugins:
+      - qt
+    extra_args: --custom-apprun "$BUILD_DIR"/AppRun.sh
+    raw_environment:
+      - LD_LIBRARY_PATH="$BUILD_DIR"/AppDir/usr/conda/lib

--- a/external/pybind11/CMakeLists.txt
+++ b/external/pybind11/CMakeLists.txt
@@ -5,7 +5,7 @@
 # All rights reserved. Use of this source code is governed by a
 # BSD-style license that can be found in the LICENSE file.
 
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.6)
 
 if (POLICY CMP0048)
   # cmake warns if loaded from a min-3.0-required parent dir, so silence the warning:
@@ -34,12 +34,6 @@ include(pybind11Tools)
 
 # Cache variables so pybind11_add_module can be used in parent projects
 set(PYBIND11_INCLUDE_DIR "${CMAKE_CURRENT_LIST_DIR}/include" CACHE INTERNAL "")
-set(PYTHON_INCLUDE_DIRS ${PYTHON_INCLUDE_DIRS} CACHE INTERNAL "")
-set(PYTHON_LIBRARIES ${PYTHON_LIBRARIES} CACHE INTERNAL "")
-set(PYTHON_MODULE_PREFIX ${PYTHON_MODULE_PREFIX} CACHE INTERNAL "")
-set(PYTHON_MODULE_EXTENSION ${PYTHON_MODULE_EXTENSION} CACHE INTERNAL "")
-set(PYTHON_VERSION_MAJOR ${PYTHON_VERSION_MAJOR} CACHE INTERNAL "")
-set(PYTHON_VERSION_MINOR ${PYTHON_VERSION_MINOR} CACHE INTERNAL "")
 
 # NB: when adding a header don't forget to also add it to setup.py
 set(PYBIND11_HEADERS
@@ -88,19 +82,18 @@ endforeach()
 set(${PROJECT_NAME}_VERSION ${PYBIND11_VERSION_MAJOR}.${PYBIND11_VERSION_MINOR}.${PYBIND11_VERSION_PATCH})
 message(STATUS "pybind11 v${${PROJECT_NAME}_VERSION}")
 
-option (USE_PYTHON_INCLUDE_DIR "Install pybind11 headers in Python include directory instead of default installation prefix" OFF)
-if (USE_PYTHON_INCLUDE_DIR)
-    file(RELATIVE_PATH CMAKE_INSTALL_INCLUDEDIR ${CMAKE_INSTALL_PREFIX} ${PYTHON_INCLUDE_DIRS})
-endif()
+find_package(PkgConfig)
+pkg_check_modules(PYTHON3 python3 IMPORTED_TARGET)
 
 if(NOT (CMAKE_VERSION VERSION_LESS 3.0))  # CMake >= 3.0
   # Build an interface library target:
   add_library(pybind11 INTERFACE)
   add_library(pybind11::pybind11 ALIAS pybind11)  # to match exported target
+  target_link_libraries(pybind11 INTERFACE PkgConfig::PYTHON3)
   target_include_directories(pybind11 INTERFACE $<BUILD_INTERFACE:${PYBIND11_INCLUDE_DIR}>
-                                                $<BUILD_INTERFACE:${PYTHON_INCLUDE_DIRS}>
                                                 $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
   target_compile_options(pybind11 INTERFACE $<BUILD_INTERFACE:${PYBIND11_CPP_STANDARD}>)
+  target_link_directories(pybind11 INTERFACE $<BUILD_INTERFACE:${PYTHON3_LIBRARY_DIRS}>)
 
   add_library(module INTERFACE)
   add_library(pybind11::module ALIAS module)


### PR DESCRIPTION
This PR introduces support for building AppImages of SmuView with [appimagecraft](https://github.com/TheAssassin/appimagecraft/).

I had to fix a few CMake issues. I think my solutions are pretty elegant (I love `IMPORTED_TARGET`), but you'll have to check whether this breaks your MXE etc. builds.

The built AppImage doesn't run due to a minor library loading issue I haven't figured out completely. But building works flawlessly.

The appimagecraft config automatically builds the latest libsigrok beforehand. Also it ensures there's a portable Python interpreter available in the AppImage, in `$APPDIR/usr/conda/bin/python3`. You will probably have to make sure your app will find it, but that's outside the scope of my work here.

Let me know what you think!

Edit: I haven't checked how this could be included in (if any) CI jobs etc.