### PR TITLE
interpret ConfigKey::DataSource meta packets to select...

### DIFF
--- a/src/devices/hardwaredevice.hpp
+++ b/src/devices/hardwaredevice.hpp
@@ -124,6 +124,7 @@ private:
 	double frame_start_timestamp_;
 	uint64_t cur_samplerate_;
 	shared_ptr<data::properties::UInt64Property> samplerate_prop_;
+	string cur_meta_data_source_;
 
 };
 


### PR DESCRIPTION
which Configurable to send following meta packets to.
tested this where that DataSource is actually the channel group of a 4
channel PPS.

corresponding PR for libsigrok with a 4ch PPS: https://github.com/sigrokproject/libsigrok/pull/57
especially this commit: https://github.com/sigrokproject/libsigrok/pull/57/commits/25a135c43d8e5151f372eae9087e7feff20a1217