### PR TITLE
Added feature to combine analog values based on a time window, e.g.

### DIFF
--- a/src/ui/dialogs/savedialog.hpp
+++ b/src/ui/dialogs/savedialog.hpp
@@ -63,19 +63,21 @@ public:
 private:
 	void setup_ui();
 	void save(const QString &file_name);
-	void save_combined(const QString &file_name);
+	void save_combined(const QString &file_name, const double combined_timeframe = 0);
 
 	const Session &session_;
 	const shared_ptr<sv::devices::BaseDevice> selected_device_;
 
 	ui::devices::devicetree::DeviceTreeView *device_tree_;
 	QCheckBox *timestamps_combined_;
+	QLineEdit *timestamps_combined_timeframe_;
 	QCheckBox *time_absolut_;
 	QLineEdit *separator_edit_;
 	QDialogButtonBox *button_box_;
 
 public Q_SLOTS:
 	void accept() override;
+	void toggle_combined(int state);
 
 };
 


### PR DESCRIPTION
user can specify an amount of ms where the timestamp is considered to
be equial.

Regularly frames from libsigrok arriave with two channel readings from a multimeter at the "edge" of milliseconds and are not considered equal. By providing a window value, all readings within that window of the original reading can be combined together.