### PR TITLE
Several small bug fixes / quality of life improvement

### DIFF
--- a/src/data/datautil.hpp
+++ b/src/data/datautil.hpp
@@ -425,6 +425,7 @@ map<const sigrok::Quantity *, Quantity> sr_quantity_quantity_map = {
 	{ sigrok::Quantity::MASS, Quantity::Mass },
 	{ sigrok::Quantity::HARMONIC_RATIO, Quantity::HarmonicRatio },
 	{ sigrok::Quantity::ENERGY, Quantity::Energy },
+	{ sigrok::Quantity::ELECTRIC_CHARGE, Quantity::ElectricCharge },
 };
 
 map<Quantity, const sigrok::Quantity *> quantity_sr_quantity_map = {
@@ -462,6 +463,8 @@ map<Quantity, const sigrok::Quantity *> quantity_sr_quantity_map = {
 	{ Quantity::Mass, sigrok::Quantity::MASS },
 	{ Quantity::HarmonicRatio, sigrok::Quantity::HARMONIC_RATIO },
 	{ Quantity::Energy, sigrok::Quantity::ENERGY },
+	{ Quantity::ElectricCharge, sigrok::Quantity::ELECTRIC_CHARGE },
+
 };
 
 map<const sigrok::QuantityFlag *, QuantityFlag> sr_quantity_flag_quantity_flag_map = {

--- a/src/ui/dialogs/connectdialog.hpp
+++ b/src/ui/dialogs/connectdialog.hpp
@@ -74,13 +74,16 @@ public:
 	shared_ptr<sv::devices::HardwareDevice> get_selected_device() const;
 
 private:
-	void populate_drivers();
+	void populate_drivers(std::set<const sigrok::ConfigKey *> filters_set =
+		std::set<const sigrok::ConfigKey *>());
+	void populate_filters();
 	void populate_serials_start(shared_ptr<sigrok::Driver> driver);
 	void populate_serials_thread_proc(shared_ptr<sigrok::Driver> driver);
 	void check_available_libs();
 	void unset_connection();
 
 private Q_SLOTS:
+	void filter_selected(int index);
 	void driver_selected(int index);
 	void serial_toggled(bool checked);
 	void tcp_toggled(bool checked);
@@ -99,6 +102,7 @@ private:
 	QWidget form_;
 	QFormLayout form_layout_;
 
+	QComboBox filters_;
 	QComboBox drivers_;
 
 	QRadioButton *radiobtn_usb_;

--- a/src/ui/dialogs/generatewaveformdialog.cpp
+++ b/src/ui/dialogs/generatewaveformdialog.cpp
@@ -299,10 +299,9 @@ void GenerateWaveformDialog::accept()
 		else if (w_type == WaveformType::Triangle)
 			value = (std::asin(std::sin(x))) / (pi/2);
 		else if (w_type == WaveformType::Sawtooth)
-			// y = −arctan(cotan(x))
-			value = -1 * std::atan(1 / std::tan(x)) / (pi/2);
+			value = std::fmod(x / pi, 2.0) - 1.0;
 		else if (w_type == WaveformType::SawtoothInv)
-			value = std::atan(1 / std::tan(x)) / (pi/2);
+			value = -std::fmod(x / pi, 2.0) + 1.0;
 		else
 			value = 0;
 

--- a/src/ui/views/powerpanelview.cpp
+++ b/src/ui/views/powerpanelview.cpp
@@ -85,10 +85,23 @@ PowerPanelView::~PowerPanelView()
 
 QString PowerPanelView::title() const
 {
-	QString title = tr("Power Panel");
-	if (voltage_signal_ && current_signal_)
-		title = title.append(" ").append(voltage_signal_->display_name()).
-			append(" / ").append(current_signal_->display_name());
+	QString title = tr("Power Panel : ");
+	if (voltage_signal_ && current_signal_) {
+		auto voltage_device = voltage_signal_->parent_channel()->parent_device();
+		auto current_device = current_signal_->parent_channel()->parent_device();
+
+		if (voltage_device == current_device)
+			title = title.append("%1 %2 / %3")
+					.arg(voltage_device->display_name(session_.device_manager()))
+					.arg(voltage_signal_->display_name())
+					.arg(current_signal_->display_name());
+		else
+			title = title.append("%1 %2 / %3 %4")
+					.arg(voltage_device->display_name(session_.device_manager()))
+					.arg(voltage_signal_->display_name())
+					.arg(current_device->display_name(session_.device_manager()))
+					.arg(current_signal_->display_name());
+	}
 
 	return title;
 }


### PR DESCRIPTION
This PR contains :
1. Addition of a ComboBox containing the different device types known to Sigrok. Only the devices matching the type selected are then listed. The default "Any device type" shows all devices just as before.
2. Add device name to title of Power panel
3. Fix sawtooth generator period being half the requested period
4. Added missing Electric Charge quantity, that is need to properly identify signals of that type.


