### PR TITLE
Fix corrupt analog data for non-float values

### DIFF
--- a/src/channels/hardwarechannel.cpp
+++ b/src/channels/hardwarechannel.cpp
@@ -116,7 +116,7 @@ void HardwareChannel::push_interleaved_samples(const float *data,
 
 	static_pointer_cast<data::AnalogTimeSignal>(actual_signal_)->push_samples(
 		deint_data.get(), sample_count, timestamp, samplerate,
-		sr_analog->unitsize(), total_digits, sr_analog->digits());
+		sizeof(float), total_digits, sr_analog->digits());
 }
 
 } // namespace channels

--- a/src/ui/views/dataview.cpp
+++ b/src/ui/views/dataview.cpp
@@ -244,7 +244,7 @@ void DataView::on_action_auto_scroll_triggered()
 void DataView::on_action_add_signal_triggered()
 {
 	shared_ptr<sv::devices::BaseDevice> selected_device;
-	if (signals_[0])
+	if (!signals_.empty() && signals_[0])
 		selected_device = signals_[0]->parent_channel()->parent_device();
 
 	ui::dialogs::SelectSignalDialog dlg(session(), selected_device);


### PR DESCRIPTION
Hi,

This fixes an issue that causes invalid data in SmuView for non-float analog data. I ran into this when writing a driver for serial-dmm where the value is stored as a double. `feed_in_analog()` is getting the original value converted to float, but then `push_interleaved_samples()` is sending the original unit size (8 for double) instead of the float size and results in corrupt data. 

Let me know if there are any issues or if there's another way to tackle this - thanks!

-Nikhil